### PR TITLE
fix(fusion-deploy): Change from reusable workflow to composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ URL to the Portal where the artifact should be deployed.
 The AppKey (name of the package), as used within the Fusion Portal.
 * **publish** (optional)
 Set if the artifact should immediately be published in the Portal or not. Default true.
-
-_secrets_:
 * **azure-tenant-id**
 The Azure Tenant ID of the ServicePrincipal (Application registration) which is setup with the proper Federated Credentials.
 * **azure-client-id**

--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -13,7 +13,6 @@ on:
                 description: "Optional - determines if the deployed artifact should immediately be published or not. Default true."
                 required: false
                 default: true
-        secrets:
             azure-tenant-id:
                 description: "Id of the Azure tenant"
                 required: true
@@ -24,36 +23,35 @@ on:
                 description: "Id of the resource group for deployment"
                 required: true
 
-jobs:
-    deploy:
-        runs-on: ubuntu-latest
-        steps:
-            - name: "Download artifact"
-              uses: actions/download-artifact@v2
+runs:
+    using: "composite"
+    steps:
+        - name: "Download artifact"
+          uses: actions/download-artifact@v2
 
-            - name: "Login to Azure"
-              uses: azure/login@v1
-              with:
-                  client-id: ${{ secrets.azure-client-id }}
-                  tenant-id: ${{ secrets.azure-tenant-id }}
-                  allow-no-subscriptions: true
+        - name: "Login to Azure"
+          uses: azure/login@v1
+          with:
+              client-id: ${{ inputs.azure-client-id }}
+              tenant-id: ${{ inputs.azure-tenant-id }}
+              allow-no-subscriptions: true
 
-            - name: "Obtain token for upload"
-              run: echo "FUSION_TOKEN=$(az account get-access-token --resource '${{ secrets.azure-resource-id }}' | jq '.accessToken')" >> $GITHUB_ENV
+        - name: "Obtain token for upload"
+          run: echo "FUSION_TOKEN=$(az account get-access-token --resource '${{ inputs.azure-resource-id }}' | jq '.accessToken')" >> $GITHUB_ENV
 
-            - name: "Upload to Fusion Portal"
-              run: |
-                  curl -X POST \
-                  -i \
-                  -H "Content-Type: application/zip" \
-                  -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
-                  --data-binary @out/${{ inputs.app-key }}.zip \
-                  "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/versions"
+        - name: "Upload to Fusion Portal"
+          run: |
+              curl -X POST \
+              -i \
+              -H "Content-Type: application/zip" \
+              -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
+              --data-binary @out/${{ inputs.app-key }}.zip \
+              "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/versions"
 
-            - name: "Publish in Fusion Portal"
-              if: ${{ inputs.publish }}
-              run: |
-                  curl -X POST \
-                  -i \
-                  -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
-                  "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/publish"
+        - name: "Publish in Fusion Portal"
+          if: ${{ inputs.publish }}
+          run: |
+              curl -X POST \
+              -i \
+              -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
+              "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/publish"


### PR DESCRIPTION
Due to certain limitations in reusable workflows, fusion-deploy has been converted
to a composition action instead.

Also see:
https://chris48s.github.io/blogmarks/github/2021/11/06/composite-actions-reusable-workflows.html