### PR TITLE
fix: Publish should not be run when set to false (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ _Parameters:_
 URL to the Portal where the artifact should be deployed.
 * **app-key** (mandatory)
 The AppKey (name of the package), as used within the Fusion Portal.
+* **artifact-path** (mandatory)
+The "local" path (with filename) to the artifact to be uploaded to Fusion.
 * **publish** (optional)
 Set if the artifact should immediately be published in the Portal or not. Default true.
 * **azure-tenant-id**
@@ -20,3 +22,26 @@ The Azure Tenant ID of the ServicePrincipal (Application registration) which is 
 The Client ID of the ServicePrincipal.
 * **azure-resource-id**
 The Resource Group ID where the artifact should be deployed to.
+
+Example (`deploy` here is a _job_ in a GitHub workflow)
+```
+    deploy:
+        name: "🚀 Deploy to Fusion Portal"
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+            - name: "Download artifact"
+              uses: actions/download-artifact@v2
+              with:
+                  name: theNameOfTheArtifactThatWasUploaded.zip
+
+            - name: Deploy to Fusion Portal
+              uses: equinor/farfetched-actions/fusion-deploy@v1.0
+              with:
+                  fusion-portal-url: ${{ secrets.FUSION_PORTAL_URL }}
+                  app-key: ${{ env.FUSION_APP_KEY }}
+                  artifact-path: theNameOfTheArtifactThatWasUploaded.zip
+                  azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  azure-resource-id: ${{ secrets.AZURE_RESOURCE_ID }}
+```

--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -50,7 +50,7 @@ runs:
               "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/versions"
 
         - name: "Publish in Fusion Portal"
-          if: ${{ inputs.publish }}
+          if: ${{ inputs.publish == true }}
           shell: bash
           run: |
               curl -X POST \


### PR DESCRIPTION
Should solve the issue when `publish` is set to `false` should avoid publishing the app after uploading it to Fusion.