### PR TITLE
fix: Avoid publish if input is false

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -1,4 +1,5 @@
 name: "Deploy to Fusion Portal"
+author: "Arne Kristian Jansen"
 description: "This action will deploy to the Fusion Portal, using the provided SP and Fusion environment"
 inputs:
     fusion-portal-url:
@@ -50,12 +51,16 @@ runs:
               "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/versions"
 
         - name: "Publish in Fusion Portal"
-          if: ${{ inputs.publish == true }}
           shell: bash
           run: |
-              curl -X POST \
-              -i \
-              -f \
-              -H "Content-Length: 0" \
-              -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
-              "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/publish"
+              if ${{ inputs.publish == true }}; then
+                curl -X POST \
+                -i \
+                -f \
+                -H "Content-Length: 0" \
+                -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
+                "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/publish"
+              else
+                echo "Publish is set to false, not publishing."        
+              fi
+

--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -63,4 +63,3 @@ runs:
               else
                 echo "Publish is set to false, not publishing."        
               fi
-


### PR DESCRIPTION
If-statements in `composite` actions _should_ work:
https://github.com/actions/runner/issues/834

However, we are not able to make it work here, so we instead "move" the if-statement to within the execution part of the job.
Inspired from: https://raghu-bhupatiraju.dev/github-actions-if-condition-false-positive-solved-c3313b98fbac