### PR TITLE
fix: Treat publish as string when comparing

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -53,7 +53,7 @@ runs:
         - name: "Publish in Fusion Portal"
           shell: bash
           run: |
-              if ${{ inputs.publish == true }} == 'true'; then
+              if ${{ inputs.publish == 'true' }} == 'true'; then
                 curl -X POST \
                 -i \
                 -f \


### PR DESCRIPTION
Verified with a branch. Works when comparing as a string

![image](https://user-images.githubusercontent.com/33690670/175020785-3d4a3b2c-5911-46eb-b80d-cfe94bc38ef1.png)
