### PR TITLE
chore: update-to-new-publish-uri

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -68,7 +68,7 @@ runs:
                 -f \
                 -H "Content-Length: 0" \
                 -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
-                "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/publish"
+                "${{ inputs.fusion-portal-url }}/bundles/apps/${{ inputs.app-key }}/publish"
               else
                 echo "Publish is set to false, not publishing."        
               fi

--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -31,12 +31,12 @@ runs:
         - name: "Clarify inputs"
           shell: bash
           run: |
-               echo "Using AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}" | sed -r 's/(.{0})(.{30})$/\1***/'
-               echo "Using AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}" | sed -r 's/(.{0})(.{30})$/\1***/'
-               echo "Using AZURE_RESOURCE_ID: ${{ inputs.azure-resource-id }}" | sed -r 's/(.{0})(.{30})$/\1***/'
-               echo "Using Fusion Portal URL: ${{ inputs.fusion-portal-url }}" | sed -r 's/(.{0})(.{1})$/\1***/'
-               echo "Using Fusion App Key: ${{ inputs.app-key }}"
-                
+              echo "Using AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}" | sed -r 's/(.{0})(.{30})$/\1***/'
+              echo "Using AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}" | sed -r 's/(.{0})(.{30})$/\1***/'
+              echo "Using AZURE_RESOURCE_ID: ${{ inputs.azure-resource-id }}" | sed -r 's/(.{0})(.{30})$/\1***/'
+              echo "Using Fusion Portal URL: ${{ inputs.fusion-portal-url }}" | sed -r 's/(.{0})(.{1})$/\1***/'
+              echo "Using Fusion App Key: ${{ inputs.app-key }}"
+
         - name: "Login to Azure"
           uses: azure/login@v1
           with:


### PR DESCRIPTION
Reverse-engineered from the `fdev` tool using Fiddler:

`/api/apps/{app-key}/publish` -> `/bundles/apps/{app-key}/publish`