### PR TITLE
feat!: 🎸 use fail-with-body instead of just fail

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -53,7 +53,7 @@ runs:
           run: |
               curl -X POST \
               -i \
-              -f \
+              --fail-with-body \
               -H "Content-Type: application/zip" \
               -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
               --data-binary @${{ inputs.artifact-path }} \
@@ -65,7 +65,7 @@ runs:
               if ${{ inputs.publish == 'true' }} == 'true'; then
                 curl -X POST \
                 -i \
-                -f \
+                --fail-with-body \
                 -H "Content-Length: 0" \
                 -H "Authorization: Bearer ${{ env.FUSION_TOKEN }}" \
                 "${{ inputs.fusion-portal-url }}/api/apps/${{ inputs.app-key }}/publish"


### PR DESCRIPTION
because this options gives us a chance to see the full error message not just the http code. Giving us a better chance to understand why the deployment failed

BREAKING CHANGE: 🧨 this curl option was added in version 7.76.0 which means it is only available in Ubuntu 22 and later for linux runners