### PR TITLE
Update fusion-deploy with latest azure login

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -38,7 +38,7 @@ runs:
               echo "Using Fusion App Key: ${{ inputs.app-key }}"
 
         - name: "Login to Azure"
-          uses: azure/login@v1
+          uses: azure/login@v2
           with:
               client-id: ${{ inputs.azure-client-id }}
               tenant-id: ${{ inputs.azure-tenant-id }}


### PR DESCRIPTION
Latest version of azure/login updates the node version. Updating this will remove warnings such as these 
![image](https://github.com/equinor/farfetched-actions/assets/33690670/501b9369-ad63-4528-adce-8430825359d3)
