### PR TITLE
chore: add update-yarn action

### DIFF
--- a/update-yarn/action.yml
+++ b/update-yarn/action.yml
@@ -1,0 +1,21 @@
+name: "Update Yarn"
+description: "Update Yarn to the latest version in package.json"
+runs:
+    using: "composite"
+    steps:
+        - name: Check out repository
+          uses: actions/checkout@v4
+
+        - name: Install jq
+          run: sudo apt-get install jq
+          shell: bash
+
+        - name: Enable Corepack
+          run: corepack enable
+          shell: bash
+
+        - name: Update Yarn to the latest version
+          env:
+              GH_TOKEN: ${{ github.token }}
+          run: bash ${{ github.action_path }}/update-yarn.sh
+          shell: bash

--- a/update-yarn/update-yarn.sh
+++ b/update-yarn/update-yarn.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+RED='\033[0;31m'
+LIGHT_CYAN='\033[0;36m'
+RESET='\033[0m' # No Color
+
+LABEL_NAME="yarn-update"
+
+# Create label if it doesn't exist
+if ! gh label list | grep --quiet "LABEL_NAME"; then
+  gh label create "LABEL_NAME" --color "ededed" --description "A pull request created to update the Yarn package manager version."
+fi
+
+# Ensure pull request doesn't exist
+EXISTING_YARN_PULL_REQUESTS=$(gh pr list --label "$LABEL_NAME" --state open)
+if [ -z "$EXISTING_YARN_PULL_REQUESTS" ]; then
+  echo "No existing Yarn update PR found."
+else
+  echo "Existing Yarn update PR found. Skipping update."
+  exit 0;
+fi 
+
+# Update yarn if not already updated
+PREVIOUS_YARN_VERSION=$(jq -r '.packageManager' package.json | grep -oP "yarn@\K.*")
+yarn set version stable
+NEW_YARN_VERSION=$(jq -r '.packageManager' package.json | grep -oP "yarn@\K.*")
+
+if [ "$PREVIOUS_YARN_VERSION" == "$NEW_YARN_VERSION" ]; then
+  echo -e "Yarn is already configured to use the latest version (${LIGHT_CYAN}'$LATEST_YARN_VERSION'${RESET})."
+  exit 0;
+fi
+
+echo -e "The project is configured to use ${LIGHT_CYAN}'$PREVIOUS_YARN_VERSION'${RESET}. Yarn version has been set to ${LIGHT_CYAN}'$NEW_YARN_VERSION'${RESET}, the latest version."
+
+BRANCH_NAME="yarn-update-$NEW_YARN_VERSION"
+
+# Ensure branch doesn't exist
+if git ls-remote --heads origin "$BRANCH_NAME" | grep --quiet "$BRANCH_NAME"; then
+  echo -e "${RED}Branch '$BRANCH_NAME' already exists.${RESET}" >&2
+  exit 1
+fi
+
+# Commit and push changes
+git config --global user.name 'github-actions'
+git config --global user.email 'github-actions@github.com'
+
+git checkout -b "$BRANCH_NAME"
+
+git add package.json
+git commit -m "chore: update Yarn to '$NEW_YARN_VERSION'"
+git push -u origin "$BRANCH_NAME"
+
+# Create pull request
+gh pr create \
+    --title "chore: update Yarn to '$NEW_YARN_VERSION'" \
+    --body "This PR updates Yarn to '$NEW_YARN_VERSION', the latest release." \
+    --label "$LABEL_NAME"


### PR DESCRIPTION
This action checks to see if the calling repository/branch is using the latest version of yarn. If not, a PR is created that updates to the newest one. No reviewer is requested for the created PR since that is apparently easier said than done and we have explored it previously (https://github.com/cli/cli/issues/6395#issuecomment-1269802537).

After this PR is merged, a release will be created to allow versioned access to it.

Example PR:
- https://github.com/equinor/fusion-cpr-app/pull/2299

## Overview:
If a label "yarn-update" doesn't exist, it is created.
If a PR with that label is open, the action is aborted.
Yarn set version stable is used to set the yarn version.
If the target branch already exists, the action is aborted.
The changes are committed and pushed.
A PR is created.