### PR TITLE
feat: deprecate the Fusion deploy action (#AB57396)

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -1,6 +1,6 @@
 name: "Deploy to Fusion Portal"
 author: "Arne Kristian Jansen"
-description: "This action will deploy to the Fusion Portal, using the provided SP and Fusion environment"
+description: "DEPRECATED! Fusion will remove the old project portal used by this action in the near future. Use the new app service instead: https://github.com/equinor/fusion/issues/428"
 inputs:
     fusion-portal-url:
         description: "Url to the endpoint for deployment and publishing."


### PR DESCRIPTION
Until now, apps have been uploaded to an old API called "project portal". Fusion Core is now transitioning to a new "app service" instead, and in the coming months everybody should be on that API.

The new CLI packages the app for the new service and is also capable of uploading it with a single oneliner, as long as you have the version number.

We have decided to not continue having shared code for this action and instead reimplement the action for the new CLI and app service in each repository where it's needed.

That simplifies the architecture and makes testing the actions easier and development quicker. Not all apps want to use the new CLI the same way.

You can find examples on how to use the new CLI in the push.yml and deploy-to-fusion.yml actions in these repositories:
- https://github.com/equinor/fusion-cpr-app
- https://github.com/equinor/fusion-kpd-cppm-app https://github.com/equinor/fusion-kpd-pv-app

More information can be found here:
https://fusion-docs.fusion-dev.net/blog/app-admin-v1