### PR TITLE
feat: add a PR commit name validator action (#AB58806)

### DIFF
--- a/fusion-deploy/action.yml
+++ b/fusion-deploy/action.yml
@@ -1,5 +1,4 @@
 name: "Deploy to Fusion Portal"
-author: "Arne Kristian Jansen"
 description: "DEPRECATED! Fusion will remove the old project portal used by this action in the near future. Use the new app service instead: https://github.com/equinor/fusion/issues/428"
 inputs:
     fusion-portal-url:

--- a/pr-name-validator/action.yml
+++ b/pr-name-validator/action.yml
@@ -1,5 +1,4 @@
 name: 🔍️ PR Name Validation
-author: "Andreas Dukstad & Arne Kristian Jansen"
 description: "This action will validate the name of a PR, ensuring it follows the expected naming rules."
 inputs:
     failed-pr-label:

--- a/pr-validate-conventional-commit-naming/action.yml
+++ b/pr-validate-conventional-commit-naming/action.yml
@@ -1,0 +1,34 @@
+name: 🔍️ PR Validate conventional commit naming
+description: "This action validates the PR's commit messages to make sure they follow conventional commits."
+
+runs:
+    using: "composite"
+    steps:
+        - name: "Store PR_COMMIT_COUNT"
+          shell: bash
+          run: echo "PR_COMMIT_COUNT=${{ github.event.pull_request.commits }}" >> "${GITHUB_ENV}"
+        - name: Checkout repository
+          uses: actions/checkout@v3
+          with:
+              fetch-depth: $(( ${{ env.PR_COMMIT_COUNT }} + 1 ))
+        - name: Validate conventional commits
+          shell: bash
+          run: |
+              ALLOWED_PREFIXES="feat|fix|chore|refactor|docs|style|test|perf|ci|build"
+
+              # There is a hidden merge commit at the top that we bypass. The second child is the topmost PR commit.
+              COMMIT_MESSAGES=$(git log origin/${{ github.event.pull_request.base.ref }}..HEAD^2 --pretty=format:'%s')
+
+              echo "Found the following commit messages:"
+              echo "$COMMIT_MESSAGES"
+              echo
+
+              # Validate each commit message
+              echo "$COMMIT_MESSAGES" | while IFS= read -r commit; do
+                if [[ ! $commit =~ ^($ALLOWED_PREFIXES)(\(.+\))?!?:.*$ ]]; then
+                  echo "Invalid commit message: $commit"
+                  exit 1
+                fi
+              done
+
+              echo "All commit messages follow the Conventional Commit format."


### PR DESCRIPTION
The action makes sure that every commit in a PR follows conventional commit naming.