### PR TITLE
feat(pr-validate-conventional-commit-naming): allow standard git revert messages (#AB68885)

### DIFF
--- a/pr-name-validator/action.yml
+++ b/pr-name-validator/action.yml
@@ -13,7 +13,7 @@ runs:
 
               echo "PR Title: $PR_TITLE"
 
-              if [[ ! "$PR_TITLE" =~ ^($ALLOWED_PREFIXES)(\(.+\))?!?:.*$ ]]; then
+              if [[ ! "$PR_TITLE" =~ ^($ALLOWED_PREFIXES)(\(.+\))?!?:.*$ && ! "$PR_TITLE" =~ ^Revert\ \".*\"$ ]]; then
                 echo "The PR title is invalid: $PR_TITLE"
                 echo "It must follow the conventional commit format." 
                 exit 1

--- a/pr-name-validator/action.yml
+++ b/pr-name-validator/action.yml
@@ -9,7 +9,7 @@ runs:
           env:
               PR_TITLE: ${{ github.event.pull_request.title }}
           run: |
-              ALLOWED_PREFIXES="feat|fix|chore|refactor|docs|style|test|perf|ci|build"
+              ALLOWED_PREFIXES="feat|fix|chore|refactor|docs|style|test|perf|ci|build|revert"
 
               echo "PR Title: $PR_TITLE"
 

--- a/pr-validate-conventional-commit-naming/action.yml
+++ b/pr-validate-conventional-commit-naming/action.yml
@@ -14,7 +14,7 @@ runs:
         - name: Validate conventional commits
           shell: bash
           run: |
-              ALLOWED_PREFIXES="feat|fix|chore|refactor|docs|style|test|perf|ci|build"
+              ALLOWED_PREFIXES="feat|fix|chore|refactor|docs|style|test|perf|ci|build|revert"
 
               # There is a hidden merge commit at the top that we bypass. The second child is the topmost PR commit.
               COMMIT_MESSAGES=$(git log origin/${{ github.event.pull_request.base.ref }}..HEAD^2 --pretty=format:'%s')


### PR DESCRIPTION
Adjust commit validation to allow standard git revert messages.