### PR TITLE
chore: pin GH action version by SHA (#AB68548)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,7 +28,7 @@ jobs:
             pull-requests: write
         steps:
             - name: "Dependency Review"
-              uses: actions/dependency-review-action@v5.0.0
+              uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
               # See https://github.com/actions/dependency-review-action#configuration-options for all available options.
               with:
                   comment-summary-in-pr: always

--- a/.github/workflows/governance-docs-version-check.yml
+++ b/.github/workflows/governance-docs-version-check.yml
@@ -16,7 +16,7 @@ jobs:
             COMPLIANCE_DOC: "docs/compliance/COMPLIANCE.md"
             BRANCH: "chore/gov-docs-version-check-${{github.run_id}}-${{github.run_number}}"
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: main
             - name: Create branch and update file

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,8 @@ jobs:
             contents: read
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: "lts/*"
             - name: Find code style issues

--- a/pr-validate-conventional-commit-naming/action.yml
+++ b/pr-validate-conventional-commit-naming/action.yml
@@ -8,7 +8,7 @@ runs:
           shell: bash
           run: echo "PR_COMMIT_COUNT=${{ github.event.pull_request.commits }}" >> "${GITHUB_ENV}"
         - name: Checkout repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with:
               fetch-depth: $(( ${{ env.PR_COMMIT_COUNT }} + 1 ))
         - name: Validate conventional commits

--- a/update-yarn/action.yml
+++ b/update-yarn/action.yml
@@ -4,7 +4,7 @@ runs:
     using: "composite"
     steps:
         - name: Check out repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
         - name: Install jq
           run: sudo apt-get install jq

--- a/wait-for-version/action.yml
+++ b/wait-for-version/action.yml
@@ -16,7 +16,7 @@ runs:
     using: "composite"
     steps:
         - name: Check out repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
         - name: Install jq
           run: sudo apt-get install jq


### PR DESCRIPTION
External GH actions are now pinned by SHA. Used the versions and SHAs from a couple weeks ago when I did this for the blue-team apps. Some of the actions were upgraded several major versions by this, and some that only specified a major version may be downgraded. Dependabot should fix that within 24 hours, though.